### PR TITLE
[FIX] intercompany : useless and buggy sudo

### DIFF
--- a/intercompany_trade_account/models/account_invoice_line.py
+++ b/intercompany_trade_account/models/account_invoice_line.py
@@ -32,7 +32,7 @@ class AccountInvoiceLine(models.Model):
         # Create according account invoice line
         customer_product = config.get_customer_product(
             self.product_id
-        ).sudo(config.customer_user_id)
+        )
 
         if not customer_product:
             raise UserError(


### PR DESCRIPTION
For deck : card/1202

Fonctionne sans sudo qui lève une erreur si la recherche de produit n'est pas fructueuse quand la company cliente n'a pas référencé.
Sans ce sudo, la validation renvoie proprement l'erreur après si il manque ce référencement
